### PR TITLE
List the imported models

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -95,11 +95,11 @@ def list_bedrock_models() -> dict:
             profile_list = [p['inferenceProfileId'] for p in response['inferenceProfileSummaries']]
 
         # List foundation models, only cares about text outputs here.
-        response = bedrock_client.list_foundation_models(
+        foundation_models_response = bedrock_client.list_foundation_models(
             byOutputModality='TEXT'
         )
 
-        for model in response['modelSummaries']:
+        for model in foundation_models_response['modelSummaries']:
             model_id = model.get('modelId', 'N/A')
             stream_supported = model.get('responseStreamingSupported', True)
             status = model['modelLifecycle'].get('status', 'ACTIVE')
@@ -122,6 +122,15 @@ def list_bedrock_models() -> dict:
                 model_list[profile_id] = {
                     'modalities': input_modalities
                 }
+
+        # List imported models
+        imported_models_response = bedrock_client.list_imported_models()
+
+        for model in imported_models_response['modelSummaries']:
+            model_id = model.get('modelArn')
+            model_list[model_id] = {
+                'modalities': ["TEXT"]
+            }
 
     except Exception as e:
         logger.error(f"Unable to list models: {str(e)}")

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -123,11 +123,11 @@ def list_bedrock_models() -> dict:
                     'modalities': input_modalities
                 }
 
-        # List imported models
+        # List the imported models
         imported_models_response = bedrock_client.list_imported_models()
 
         for model in imported_models_response['modelSummaries']:
-            model_id = model.get('modelArn')
+            model_id = model.get('modelArn', 'N/A')
             model_list[model_id] = {
                 'modalities': ["TEXT"]
             }

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  bedrock-access-gateway:
+    image: bedrock-access-gateway
+    build:
+      context: .
+      dockerfile: Dockerfile_ecs
+    ports:
+      - "8000:80"
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_REGION:-us-east-1}
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      DEBUG: "true"


### PR DESCRIPTION
*Description of changes:*
Add the imported models. Enable the imported models to be served by the gateway.

Check that the environment variables are set correctly:

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_REGION`

As of mid February 2025, Amazon Bedrock Custom Model Import is supported in the following Regions:
- US East (N. Virginia)
- US West (Oregon)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
