### PR TITLE
Call invoke_model_with_response_stream if the model does not support converse_stream

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,8 +1,12 @@
 # SEA-LION Amazon Bedrock Custom Model Import Demo
 
+## Posts
+- [Importing and Using SEA-LION in a Serverless, On-Demand Environment with Amazon Bedrock](https://sea-lion.ai/importing-and-using-sea-lion-in-a-serverless-on-demand-environment-with-amazon-bedrock/)
+- [OpenAI-compatible APIs with SEA-LION and Bedrock Access Gateway](https://sea-lion.ai/openai-compatible-apis-with-sea-lion-and-bedrock-access-gateway/)
+
 ## Setup
 > [!NOTE]
-> At the time of writing, Amazon Bedrock Custom Model Import is available in the `us-east-1` and `us-west-2` AWS regions.
+> At the time of writing, Amazon Bedrock Custom Model Import is available in the `us-east-1`, `us-west-2` and `eu-central-1` AWS regions. The [supported model architectures](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html#model-customization-import-model-architecture) include Llama 3 and Llama 3.1.
 
 - Upload the [SEA-LION model](https://huggingface.co/aisingapore/Llama-SEA-LION-v3-8B-IT) to an Amazon S3 bucket.
 - Navigate to **Imported models** in the Amazon Bedrock console. Click the **Import model** button.

--- a/demo/sealion_bedrock.py
+++ b/demo/sealion_bedrock.py
@@ -51,29 +51,30 @@ def stream_openai_response(openai_client, conversation: List[Dict[str, Any]]):
             max_tokens=max_tokens,
             temperature=temperature,
         )
-    except (ClientError, Exception) as e:
+
+        # Process the stream
+        assistant_message = ""
+        for part in stream:
+            # Get the content from the stream
+            content = part.choices[0].delta.content or ""
+
+            # Filter out new lines and line feeds
+            filtered_content = content.replace("\n", "").replace("\r", "")
+
+            # Append to the assistant's message
+            assistant_message += filtered_content
+
+            # Print the filtered content
+            print(filtered_content, end="", flush=True)
+
+        print()
+
+        # Append the assistant's reply to the conversation
+        conversation.append({"role": "assistant", "content": assistant_message})
+
+    except Exception as e:
         logging.error(f"Exception: {e}")
         sys.exit(1)
-
-    # Process the stream
-    assistant_message = ""
-    for part in stream:
-        # Get the content from the stream
-        content = part.choices[0].delta.content or ""
-
-        # Filter out new lines and line feeds
-        filtered_content = content.replace("\n", "").replace("\r", "")
-
-        # Append to the assistant's message
-        assistant_message += filtered_content
-
-        # Print the filtered content
-        print(filtered_content, end="", flush=True)
-
-    print()
-
-    # Append the assistant's reply to the conversation
-    conversation.append({"role": "assistant", "content": assistant_message})
 
 
 def stream_bedrock_response_with_invoke_model(bedrock_client, conversation: List[Dict[str, Any]]):

--- a/demo/sealion_bedrock.py
+++ b/demo/sealion_bedrock.py
@@ -77,7 +77,9 @@ def stream_openai_response(openai_client, conversation: List[Dict[str, Any]]):
         sys.exit(1)
 
 
-def stream_bedrock_response_with_invoke_model(bedrock_client, conversation: List[Dict[str, Any]]):
+def stream_bedrock_response_with_invoke_model(
+    bedrock_client, conversation: List[Dict[str, Any]]
+):
     """
     Stream the response from Bedrock with invoke_model_with_response_stream.
     Used for the models that do not support converse_stream.
@@ -86,15 +88,16 @@ def stream_bedrock_response_with_invoke_model(bedrock_client, conversation: List
         bedrock_client: The Bedrock client.
         conversation (List[Dict[str, Any]]): The conversation history.
     """
-    request = json.dumps({
-        "prompt": conversation[-1]["content"],
-        "max_gen_len": max_tokens,
-        "temperature": temperature,
-    })
+    request = json.dumps(
+        {
+            "prompt": conversation[-1]["content"],
+            "max_gen_len": max_tokens,
+            "temperature": temperature,
+        }
+    )
     try:
         streaming_response = bedrock_client.invoke_model_with_response_stream(
-            modelId=endpoint_arn,
-            body=request
+            modelId=endpoint_arn, body=request
         )
         for event in streaming_response["body"]:
             chunk = json.loads(event["chunk"]["bytes"])
@@ -102,7 +105,9 @@ def stream_bedrock_response_with_invoke_model(bedrock_client, conversation: List
                 print(chunk["generation"], end="")
         print()
     except bedrock_client.exceptions.ModelNotReadyException:
-        logging.error("The model is not ready for inference. Please wait and try again later.")
+        logging.error(
+            "The model is not ready for inference. Please wait and try again later."
+        )
         sys.exit(1)
     except Exception as e:
         logging.error(f"Exception: {e}")
@@ -145,7 +150,9 @@ def stream_bedrock_response(bedrock_client, conversation: List[Dict[str, Any]]):
             return
         raise
     except bedrock_client.exceptions.ModelNotReadyException:
-        logging.error("The model is not ready for inference. Please wait and try again later.")
+        logging.error(
+            "The model is not ready for inference. Please wait and try again later."
+        )
         sys.exit(1)
     except Exception as e:
         logging.error(f"Exception: {e}")
@@ -175,10 +182,14 @@ def main():
         logging.info("Using the OpenAI-compatible API.")
         openai_client = OpenAI(base_url=openai_base_url, api_key="bedrock")
     else:
-        logging.info("Using the Amazon Bedrock Runtime (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Amazon_Bedrock_Runtime.html).")
+        logging.info(
+            "Using the Amazon Bedrock Runtime (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Amazon_Bedrock_Runtime.html)."
+        )
         bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
 
-    print("This demo application is built for the imported SEA-LION models (https://sea-lion.ai/our-models/) with Llama architecture.")
+    print(
+        "This demo application is built for the imported SEA-LION models (https://sea-lion.ai/our-models/) with Llama architecture."
+    )
     print("Welcome! Type your message or /bye to end.")
 
     # Initialize the conversation history

--- a/demo/sealion_bedrock.py
+++ b/demo/sealion_bedrock.py
@@ -138,6 +138,7 @@ def stream_bedrock_response(bedrock_client, conversation: List[Dict[str, Any]]):
             },
         )
     except ClientError as e:
+        # If the imported model does not support converse_stream, an exception will be raised
         if "ConverseStream operation" in str(e):
             stream_bedrock_response_with_invoke_model(bedrock_client, conversation)
             return
@@ -176,6 +177,7 @@ def main():
         logging.info("Using the Amazon Bedrock Runtime (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Amazon_Bedrock_Runtime.html).")
         bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
 
+    print("This demo application is built for the imported SEA-LION models (https://sea-lion.ai/our-models/) with Llama architecture.")
     print("Welcome! Type your message or /bye to end.")
 
     # Initialize the conversation history

--- a/demo/sealion_bedrock.py
+++ b/demo/sealion_bedrock.py
@@ -1,12 +1,16 @@
 import argparse
 import boto3
 import logging
+import json
 import os
 import sys
 from botocore.exceptions import ClientError
 from dotenv import load_dotenv
 from openai import OpenAI
 from typing import Any, Dict, List
+
+# Set the log level
+logging.basicConfig(level=logging.INFO)
 
 # Load the environment variables
 load_dotenv()
@@ -19,6 +23,10 @@ try:
     openai_base_url = os.environ["API_URL"]
     temperature = float(os.environ.get("TEMPERATURE", 0.0))
     top_k = int(os.environ.get("TOP_K", 250))
+
+    # Log the settings
+    logging.info(f"AWS Region: {aws_region}")
+    logging.info(f"Endpoint ARN: {endpoint_arn}")
 except KeyError as e:
     logging.error(f"The environment variable {e} is not defined.")
     sys.exit(1)
@@ -68,6 +76,38 @@ def stream_openai_response(openai_client, conversation: List[Dict[str, Any]]):
     conversation.append({"role": "assistant", "content": assistant_message})
 
 
+def stream_bedrock_response_with_invoke_model(bedrock_client, conversation: List[Dict[str, Any]]):
+    """
+    Stream the response from Bedrock with invoke_model_with_response_stream.
+    Used for the models that do not support converse_stream.
+
+    Args:
+        bedrock_client: The Bedrock client.
+        conversation (List[Dict[str, Any]]): The conversation history.
+    """
+    request = json.dumps({
+        "prompt": conversation[-1]["content"],
+        "max_gen_len": max_tokens,
+        "temperature": temperature,
+    })
+    try:
+        streaming_response = bedrock_client.invoke_model_with_response_stream(
+            modelId=endpoint_arn,
+            body=request
+        )
+        for event in streaming_response["body"]:
+            chunk = json.loads(event["chunk"]["bytes"])
+            if "generation" in chunk:
+                print(chunk["generation"], end="")
+        print()
+    except bedrock_client.exceptions.ModelNotReadyException:
+        logging.error("The model is not ready for inference. Please wait and try again later.")
+        sys.exit(1)
+    except Exception as e:
+        logging.error(f"Exception: {e}")
+        sys.exit(1)
+
+
 def stream_bedrock_response(bedrock_client, conversation: List[Dict[str, Any]]):
     """
     Stream the response from Bedrock.
@@ -97,7 +137,15 @@ def stream_bedrock_response(bedrock_client, conversation: List[Dict[str, Any]]):
                 }
             },
         )
-    except (ClientError, Exception) as e:
+    except ClientError as e:
+        if "ConverseStream operation" in str(e):
+            stream_bedrock_response_with_invoke_model(bedrock_client, conversation)
+            return
+        raise
+    except bedrock_client.exceptions.ModelNotReadyException:
+        logging.error("The model is not ready for inference. Please wait and try again later.")
+        sys.exit(1)
+    except Exception as e:
         logging.error(f"Exception: {e}")
         sys.exit(1)
 
@@ -122,10 +170,10 @@ def main():
     )
     args = parser.parse_args()
     if args.api:
-        print("Using the OpenAI-compatible API.")
+        logging.info("Using the OpenAI-compatible API.")
         openai_client = OpenAI(base_url=openai_base_url, api_key="bedrock")
     else:
-        print("Using the Amazon Bedrock Runtime (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Amazon_Bedrock_Runtime.html).")
+        logging.info("Using the Amazon Bedrock Runtime (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Amazon_Bedrock_Runtime.html).")
         bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
 
     print("Welcome! Type your message or /bye to end.")


### PR DESCRIPTION
*Description of changes:*
Call [invoke_model_with_response_stream](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/invoke_model_with_response_stream.html) if the model does not support converse_stream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
